### PR TITLE
Added Shift+Super+1 to launch new instances of applications when using Unity bindings

### DIFF
--- a/dbx_preference
+++ b/dbx_preference
@@ -1283,7 +1283,12 @@ class PrefDialog():
         self.number_shortcuts_cb.connect("toggled",
                                              self.__checkbutton_toggled,
                                              "use_number_shortcuts")
+        self.number_shortcuts_shift_launch_cb = Gtk.CheckButton.new_with_label(_("Shift+Number to launch new instances (Super+number)"))
+        self.number_shortcuts_shift_launch_cb.connect("toggled",
+                                                      self.__checkbutton_toggled,
+                                                      "use_number_shortcuts_shift_launch")
         table.attach(self.number_shortcuts_cb, 0, i + 4, 4, 1)
+        table.attach(self.number_shortcuts_shift_launch_cb, 0, i + 5, 4, 1)
         table.set_border_width(5)
         frame.add(table)
         advanced_box.pack_start(frame, False, False, 5)
@@ -1816,6 +1821,9 @@ class PrefDialog():
                self.globals.settings["gkeys_select_next_group_skip_launchers"])
         self.number_shortcuts_cb.set_active(
                                 self.globals.settings["use_number_shortcuts"])
+        self.number_shortcuts_shift_launch_cb.set_active(
+                                self.globals.settings["use_number_shortcuts_shift_launch"])
+        self.number_shortcuts_shift_launch_cb.set_sensitive(self.globals.settings["use_number_shortcuts"])
 
         # Dock page
         self.dock_size_spin.set_value(self.globals.settings["dock/size"])

--- a/dockbarx/common.py
+++ b/dockbarx/common.py
@@ -652,6 +652,8 @@ class Globals(GObject.GObject):
         "gkey-changed": (GObject.SignalFlags.RUN_FIRST, None,()),
         "use-number-shortcuts-changed": (GObject.SignalFlags.RUN_FIRST,
                                          None,()),
+        "use-number-shortcuts-shift-launch-changed": (GObject.SignalFlags.RUN_FIRST,
+                                                      None,()),
         "show-close-button-changed": (GObject.SignalFlags.RUN_FIRST,
                                       None,()),
         "dock-size-changed": (GObject.SignalFlags.RUN_FIRST, None,()),
@@ -778,6 +780,7 @@ class Globals(GObject.GObject):
           "gkeys_select_previous_window_keystr": "<super><control><shift>Tab",
           "gkeys_select_next_group_skip_launchers": False,
           "use_number_shortcuts": True,
+          "use_number_shortcuts_shift_launch": True,
           "launchers": [],
 
           "dock/theme_file": "dbx.tar.gz",
@@ -929,6 +932,8 @@ class Globals(GObject.GObject):
             self.emit("unity-changed")
         elif "use_number_shortcuts" == key:
             self.emit("use-number-shortcuts-changed")
+        elif "use_number_shortcuts_shift_launch" == key:
+            self.emit("use-number-shortcuts-shift-launch-changed")
         elif key == "theme":
             self.emit("theme-changed")
         elif key.startswith("color"):

--- a/org.dockbar.dockbarx.gschema.xml
+++ b/org.dockbar.dockbarx.gschema.xml
@@ -753,11 +753,19 @@
 
     <key name='use-number-shortcuts' type='b'>
       <default>false</default>
-      <summary>Select applications usning super+number shortcuts</summary>
+      <summary>Select applications using super+number shortcuts</summary>
       <description>
         Select applications usning super+number shortcuts.
         Eg. super+1 to select the next window of the first application and
         shift+super+1 to select the previous window of the first application.
+      </description>
+    </key>
+
+    <key name='use-number-shortcuts-shift-launch' type='b'>
+      <default>false</default>
+      <summary>Launch new instance of an application with super+shift+number shortcuts</summary>
+      <description>
+        After hitting super+shift+1, an new instance of the first application will be launched.
       </description>
     </key>
 


### PR DESCRIPTION
This mimics Windows 7 style where `Shift + Super + <Number>` opens a new instance of the application.

I can't live without this feature.

I've had it in my local repo for literally years. Today I tidied it up so that it can be toggled from settings for users who may not like this feature.