### PR TITLE
No window list

### DIFF
--- a/dbx_preference
+++ b/dbx_preference
@@ -841,23 +841,22 @@ class PrefDialog():
 
         #--- Popup page
         popup_box.set_border_width(5)
-        self.reorder_window_list_cb = Gtk.CheckButton.new_with_label(
-                          _("Reorder the window list so that the last activated window is first in the list."))
-        self.reorder_window_list_cb.connect("toggled", self.__checkbutton_toggled,
-                                 "reorder_window_list")
-        popup_box.pack_start(self.reorder_window_list_cb, False, True, 5)
+        self.no_window_list_cb = Gtk.CheckButton.new_with_label(
+                          _("Don't show window list on mouse hover"))
+        self.no_window_list_cb.connect("toggled", self.__checkbutton_toggled,
+                                 "groupbutton_no_window_list")
+        self.no_window_list_cb.set_tooltip_text(_("You can access the window list by right clicking on the button twice"))
+        popup_box.pack_start(self.no_window_list_cb, False, True, 5)
         self.no_popup_cb = Gtk.CheckButton.new_with_label(
                           _("Show window list only if more than one window is open"))
         self.no_popup_cb.connect("toggled", self.__checkbutton_toggled,
                                  "no_popup_for_one_window")
         popup_box.pack_start(self.no_popup_cb, False, True, 5)
-
-        self.no_tooltip_cb = Gtk.CheckButton.new_with_label(
-                          _("No tooltip"))
-        self.no_tooltip_cb.connect("toggled", self.__checkbutton_toggled,
-                                 "groupbutton_no_tooltip")
-        popup_box.pack_start(self.no_tooltip_cb, False, True, 5)
-
+        self.reorder_window_list_cb = Gtk.CheckButton.new_with_label(
+                          _("Reorder the window list so that the last activated window is first in the list."))
+        self.reorder_window_list_cb.connect("toggled", self.__checkbutton_toggled,
+                                 "reorder_window_list")
+        popup_box.pack_start(self.reorder_window_list_cb, False, True, 5)
         self.show_tooltip_cb = Gtk.CheckButton.new_with_label(
                           _("Show tooltip when no window is open"))
         self.show_tooltip_cb.connect("toggled", self.__checkbutton_toggled,
@@ -1616,8 +1615,8 @@ class PrefDialog():
                             self.globals.settings["no_popup_for_one_window"])
         self.show_tooltip_cb.set_active(
                             self.globals.settings["groupbutton_show_tooltip"])
-        self.no_tooltip_cb.set_active(
-                            self.globals.settings["groupbutton_no_tooltip"])
+        self.no_window_list_cb.set_active(
+                            self.globals.settings["groupbutton_no_window_list"])
 
         # Locked list
         self.locked_list_menu_cb.set_active(

--- a/dbx_preference
+++ b/dbx_preference
@@ -852,6 +852,12 @@ class PrefDialog():
                                  "no_popup_for_one_window")
         popup_box.pack_start(self.no_popup_cb, False, True, 5)
 
+        self.no_tooltip_cb = Gtk.CheckButton.new_with_label(
+                          _("No tooltip"))
+        self.no_tooltip_cb.connect("toggled", self.__checkbutton_toggled,
+                                 "groupbutton_no_tooltip")
+        popup_box.pack_start(self.no_tooltip_cb, False, True, 5)
+
         self.show_tooltip_cb = Gtk.CheckButton.new_with_label(
                           _("Show tooltip when no window is open"))
         self.show_tooltip_cb.connect("toggled", self.__checkbutton_toggled,
@@ -1610,6 +1616,8 @@ class PrefDialog():
                             self.globals.settings["no_popup_for_one_window"])
         self.show_tooltip_cb.set_active(
                             self.globals.settings["groupbutton_show_tooltip"])
+        self.no_tooltip_cb.set_active(
+                            self.globals.settings["groupbutton_no_tooltip"])
 
         # Locked list
         self.locked_list_menu_cb.set_active(

--- a/dockbarx/common.py
+++ b/dockbarx/common.py
@@ -636,6 +636,8 @@ class Globals(GObject.GObject):
         "unity-changed": (GObject.SignalFlags.RUN_FIRST, None,()),
         "show-tooltip-changed": (GObject.SignalFlags.RUN_FIRST,
                                  None,()),
+        "no-tooltip-changed": (GObject.SignalFlags.RUN_FIRST,
+                                 None,()),
         "show-previews-changed": (GObject.SignalFlags.RUN_FIRST,
                                   None,()),
         "keep-previews-changed": (GObject.SignalFlags.RUN_FIRST,
@@ -735,6 +737,7 @@ class Globals(GObject.GObject):
           "separate_ooo_apps": True,
 
           "groupbutton_show_tooltip": False,
+          "groupbutton_no_tooltip": False,
 
           "groupbutton_left_click_action": "select",
           "groupbutton_shift_and_left_click_action": "launch application",
@@ -922,6 +925,8 @@ class Globals(GObject.GObject):
             self.emit("window-title-width-changed")
         elif "groupbutton_show_tooltip" == key:
             self.emit("show-tooltip-changed")
+        elif "groupbutton_no_tooltip" == key:
+            self.emit("no-tooltip-changed")
         elif "show_close_button" == key:
             self.emit("show-close-button-changed")
         elif "media_buttons" == key:

--- a/dockbarx/common.py
+++ b/dockbarx/common.py
@@ -636,7 +636,7 @@ class Globals(GObject.GObject):
         "unity-changed": (GObject.SignalFlags.RUN_FIRST, None,()),
         "show-tooltip-changed": (GObject.SignalFlags.RUN_FIRST,
                                  None,()),
-        "no-tooltip-changed": (GObject.SignalFlags.RUN_FIRST,
+        "no-window-list-changed": (GObject.SignalFlags.RUN_FIRST,
                                  None,()),
         "show-previews-changed": (GObject.SignalFlags.RUN_FIRST,
                                   None,()),
@@ -737,7 +737,7 @@ class Globals(GObject.GObject):
           "separate_ooo_apps": True,
 
           "groupbutton_show_tooltip": False,
-          "groupbutton_no_tooltip": False,
+          "groupbutton_no_window_list": False,
 
           "groupbutton_left_click_action": "select",
           "groupbutton_shift_and_left_click_action": "launch application",
@@ -925,8 +925,8 @@ class Globals(GObject.GObject):
             self.emit("window-title-width-changed")
         elif "groupbutton_show_tooltip" == key:
             self.emit("show-tooltip-changed")
-        elif "groupbutton_no_tooltip" == key:
-            self.emit("no-tooltip-changed")
+        elif "groupbutton_no_window_list" == key:
+            self.emit("no-window-list-changed")
         elif "show_close_button" == key:
             self.emit("show-close-button-changed")
         elif "media_buttons" == key:

--- a/dockbarx/groupbutton.py
+++ b/dockbarx/groupbutton.py
@@ -1920,7 +1920,7 @@ class GroupButton(CairoAppButton):
             delay = self.globals.settings["popup_delay"]
         else:
             delay = self.globals.settings["second_popup_delay"]
-        if not self.globals.gtkmenu and not self.globals.dragging:
+        if not self.globals.gtkmenu and not self.globals.dragging and not self.globals.settings["groupbutton_no_tooltip"]:
             group.popup.show_after_delay(delay)
         self.update_state()
         # Opacify

--- a/dockbarx/groupbutton.py
+++ b/dockbarx/groupbutton.py
@@ -1920,7 +1920,7 @@ class GroupButton(CairoAppButton):
             delay = self.globals.settings["popup_delay"]
         else:
             delay = self.globals.settings["second_popup_delay"]
-        if not self.globals.gtkmenu and not self.globals.dragging and not self.globals.settings["groupbutton_no_tooltip"]:
+        if not self.globals.gtkmenu and not self.globals.dragging and not self.globals.settings["groupbutton_no_window_list"]:
             group.popup.show_after_delay(delay)
         self.update_state()
         # Opacify

--- a/org.dockbar.dockbarx.gschema.xml
+++ b/org.dockbar.dockbarx.gschema.xml
@@ -438,6 +438,14 @@
       </description>
     </key>
 
+    <key name='groupbutton-no-tooltip' type='b'>
+      <default>false</default>
+      <summary>Don't show tooltip</summary>
+      <description>
+        Don't show tooltip at all.
+      </description>
+    </key>
+
     <key name='groupbutton-left-click-action' type='s'>
       <default>"select"</default>
       <summary>Action for groupbutton left clicking</summary>

--- a/org.dockbar.dockbarx.gschema.xml
+++ b/org.dockbar.dockbarx.gschema.xml
@@ -442,7 +442,7 @@
       <default>false</default>
       <summary>Don't show window list</summary>
       <description>
-        Turn off window list completely.
+        Turn off window list on mouse hover.
       </description>
     </key>
 

--- a/org.dockbar.dockbarx.gschema.xml
+++ b/org.dockbar.dockbarx.gschema.xml
@@ -438,11 +438,11 @@
       </description>
     </key>
 
-    <key name='groupbutton-no-tooltip' type='b'>
+    <key name='groupbutton-no-window-list' type='b'>
       <default>false</default>
-      <summary>Don't show tooltip</summary>
+      <summary>Don't show window list</summary>
       <description>
-        Don't show tooltip at all.
+        Turn off window list completely.
       </description>
     </key>
 


### PR DESCRIPTION
I don't like any popup on mouse hover. With this modification, you can turn off window list on mouse hover even if more than one window are in the group. 
Other settings let you switch between windows by the mouse wheel or by clicking on the button multiple times.