### PR TITLE
get_active_window gives back None sometimes

### DIFF
--- a/dockbarx/dockbar.py
+++ b/dockbarx/dockbar.py
@@ -875,6 +875,8 @@ class DockBar():
             group.set_active_window(None)
         # Activate new windowbutton
         active_window = screen.get_active_window()
+        if active_window == None:
+            active_window = previous_active_window
         if active_window in self.windows:
             active_group_name = self.windows[active_window]
             active_group = self.groups[active_group_name]


### PR DESCRIPTION
especially with mouse wheel set to prev/next window on group.
This caused group has active window false, making the group active, inactive and active again, caused flickering
Better have prev window as active than none, so the flickering is gone.
As I tested everything works well with this patch, I hope I didn't break anything else with this.