### PR TITLE
Smart trimming of window titles

### DIFF
--- a/dbx_preference
+++ b/dbx_preference
@@ -919,6 +919,9 @@ class PrefDialog():
         self.preview_keep_cb = Gtk.CheckButton.new_with_label(_("Keep previews for minimized windows (experimental)"))
         self.preview_keep_cb.connect("toggled", self.__checkbutton_toggled, "preview_keep")
         vbox.pack_start(self.preview_keep_cb, False, True, 0)
+        self.preview_trim_cb = Gtk.CheckButton.new_with_label(_("Smart title trimming"))
+        self.preview_trim_cb.connect("toggled", self.__checkbutton_toggled, "preview_trim")
+        vbox.pack_start(self.preview_trim_cb, False, True, 0)
         popup_box.pack_start(vbox, False, True, 5)
 
         self.preview_size_spinbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
@@ -1769,6 +1772,8 @@ class PrefDialog():
         self.preview_cb.set_active(self.globals.settings["preview"])
         self.preview_keep_cb.set_active(self.globals.settings["preview_keep"])
         self.preview_keep_cb.set_sensitive(self.globals.settings["preview"])
+        self.preview_trim_cb.set_active(self.globals.settings["preview_trim"])
+        self.preview_trim_cb.set_sensitive(self.globals.settings["preview"])
         self.preview_size_spin.set_value(self.globals.settings["preview_size"])
         self.preview_size_spin.set_sensitive(self.globals.settings["preview"])
         self.window_title_width_spin.set_value(

--- a/dockbarx/windowbutton.py
+++ b/dockbarx/windowbutton.py
@@ -338,6 +338,9 @@ class WindowItem(CairoButton):
         self.press_sid = None
         self.pressed = False
 
+        self.common_prefix = ""
+        self.common_suffix = ""
+
         self.area.set_needs_attention(window.wnck.needs_attention())
 
         self.close_button = CairoCloseButton()
@@ -409,6 +412,8 @@ class WindowItem(CairoButton):
                                     self.__update_label))
         self.globals_events.append(self.globals.connect("keep-previews-changed",
                                     self.__clear_saved_preview))
+        self.globals_events.append(self.globals.connect("trim-previews-changed",
+                                    self.__clear_saved_preview))
         self.globals_events.append(self.globals.connect("show-previews-changed",
                                     self.__clear_saved_preview))
 
@@ -452,6 +457,10 @@ class WindowItem(CairoButton):
         window = self.window_r()
         group = self.group_r()
         text = escape(str(window.wnck.get_name()))
+        if text.startswith(self.common_prefix) and self.common_prefix:
+            text = "…" + text[len(self.common_prefix):]
+        if text.endswith(self.common_suffix) and self.common_suffix:
+            text = text[:-len(self.common_suffix)] + "…"
         if window.wnck.is_minimized():
             color = self.globals.colors["color4"]
         else:

--- a/org.dockbar.dockbarx.gschema.xml
+++ b/org.dockbar.dockbarx.gschema.xml
@@ -116,6 +116,14 @@
       </description>
     </key>
 
+    <key name='preview-trim' type='b'>
+      <default>false</default>
+      <summary>Smart title trimming</summary>
+      <description>
+        Remove common elements in a list of window titles
+      </description>
+    </key>
+
     <key name='old-menu' type='b'>
       <default>false</default>
       <summary>Use the old gtk style menu</summary>


### PR DESCRIPTION
Please note: this pull request is not intended for merging in its current state! This is to provide a basis for discussion, after the fixes suggested in https://github.com/xuzhen/dockbarx/issues/8.

In particular, I can't be sure this works. The title trimming works (I tested that), but now that I've added a new preference to the gsettings schema, I can't start up my version of dockbarx any more because it now throws an error: `Settings schema 'org.dockbarx.dockbarx' does not contain a key named 'preview-trim'`. I don't know how to use my "updated" gsettings schema without forcing it to install instead of the standard one, and that will break the actual installation of dockbarx that I have on my desktop! So this is a proposal, which you might want to think about, and decide whether you like it, and maybe make changes to. The full description is below.

------------------

Add a new preference, "Smart title trimming".
In the list of previews for an application, this shortens the titles of the windows in that application by removing common prefixes and suffixes from those titles. For example, if you have some Terminal windows open, with titles:
```
stuart@machine: ~ - Terminal
stuart@machine: ~/Pictures - Terminal
stuart@machine: ~/Documents - Terminal
stuart@machine: ~/.local/share - Terminal
```
then these will likely be too long to be shown in their entirety in the window list. This preference changes the displayed titles in the window list to remove the common substrings at start and end, so the entries in the list would look like this:
```
… ~ …
… ~/Pictures …
… ~/Documents …
… ~/.local/share …
```
The preference defaults to off. It's named "Smart title trimming" because more technical descriptive names such as "Remove common prefix and suffix from preview window titles" sound confusingly "techie".