### PR TITLE
Don't overwrite the launcher list while reloading

### DIFF
--- a/dockbarx/dockbar.py
+++ b/dockbarx/dockbar.py
@@ -494,6 +494,8 @@ class DockBar():
         self.keyboard_show_dock = False
         self.no_theme_change_reload = False
         self.no_dbus_reload = False
+        # True while reload() is tearing the dock down and building it up again.
+        self.reloading = False
         self.orient = "down"
 
         self.globals = Globals()
@@ -588,6 +590,12 @@ class DockBar():
     def reload(self, event=None, data=None, tell_parent=True, locked_group=None):
         """Reloads DockbarX."""
         logger.info("DockbarX reload")
+        # Don't save the launcher list while reloading. Tearing down the old
+        # group buttons triggers update_pinned_apps_list(), which would write
+        # the list that is about to be discarded over the one this reload is
+        # just about to read -- losing any launchers set from the outside
+        # while the dock was running.
+        self.reloading = True
         # Clear away the old stuff, if any.
         if self.windows:
             # Remove windows and unpinned group buttons
@@ -653,6 +661,7 @@ class DockBar():
                 identifier = None
             self.__add_launcher(identifier, path)
         # Update pinned_apps list to remove any pinned_app that are faulty.
+        self.reloading = False
         self.update_pinned_apps_list()
 
         #--- Initiate windows
@@ -1535,6 +1544,8 @@ class DockBar():
 
     def update_pinned_apps_list(self, arg=None):
         # Saves pinned_apps_list
+        if self.reloading:
+            return
         pinned_apps = []
         for group in self.groups:
             if not group.pinned:


### PR DESCRIPTION
Fixes #19.

`reload()` tears the dock down before it reads the launcher list it rebuilds from.
Removing the old group buttons goes through `remove_groupbutton()`, which calls
`update_pinned_apps_list()`, which saves the very list that is about to be discarded —
and only afterwards does `reload()` call `get_pinned_apps_list()`.

So the order on every reload is: save the current list, then read it back. A list
written to the `launchers` gsettings key from outside while the dock is running is
overwritten in between and never reaches the dock, which makes the D-Bus `Reload`
method unusable for changing the set of pinned launchers from another program.

This holds off saving while `reload()` is running: `update_pinned_apps_list()` returns
early from the start of `reload()` until the launchers have been added back, which is
where `reload()` already saves the list on purpose, to drop faulty entries. That call
stays, so faulty launchers are still dropped, and the per-group saves during the
rebuild are simply redundant with it.

Checked with `dconf watch /org/dockbarx/dockbarx/launchers` during a D-Bus `Reload`:
before, the externally written list is followed by DockbarX's old list and then that
old list rebuilt entry by entry; after, the written list survives and the dock shows it.
Pinning and unpinning by hand, and dropping a launcher whose `.desktop` has gone away,
still save as before.
