### PR TITLE
Don't leak signal handlers on reload

### DIFF
--- a/dockbarx/dockbar.py
+++ b/dockbarx/dockbar.py
@@ -588,14 +588,25 @@ class DockBar():
     def reload(self, event=None, data=None, tell_parent=True, locked_group=None):
         """Reloads DockbarX."""
         logger.info("DockbarX reload")
+        # Drop the screen signal handlers this reload is about to replace.
+        # They are connected here on every reload, but Wnck.Screen outlives
+        # the dock, so without this each reload leaves another set behind:
+        # every window event then runs all of them, the stale ones raising
+        # on state that has been torn down, until the dock is burning CPU
+        # and stops answering at all.
+        disconnect(self.screen)
         # Clear away the old stuff, if any.
         if self.windows:
             # Remove windows and unpinned group buttons
             for win in self.screen.get_windows():
                 self.__on_window_closed(None, win)
-        # Remove pinned group buttons
+        # Remove pinned group buttons. Iterate over a copy: GroupList is a
+        # list, and removing from the list being iterated skips every other
+        # group. The skipped ones never get destroy()ed, so the handlers they
+        # hold on the globals singleton -- which outlives them -- are never
+        # disconnected, and every reload leaves another batch behind.
         if self.groups is not None:
-            for group in self.groups:
+            for group in list(self.groups):
                 self.groups.remove(group)
                 group.destroy()
             self.groups.destroy()
@@ -666,14 +677,14 @@ class DockBar():
                     group.add_locked_popup()
                     break
 
-        self.screen.connect("window-opened", self.__on_window_opened)
-        self.screen.connect("window-closed", self.__on_window_closed)
-        self.screen.connect("active-window-changed",
-                            self.__on_active_window_changed)
-        self.screen.connect("viewports-changed",
-                            self.__on_desktop_changed)
-        self.screen.connect("active-workspace-changed",
-                            self.__on_desktop_changed)
+        connect(self.screen, "window-opened", self.__on_window_opened)
+        connect(self.screen, "window-closed", self.__on_window_closed)
+        connect(self.screen, "active-window-changed",
+                self.__on_active_window_changed)
+        connect(self.screen, "viewports-changed",
+                self.__on_desktop_changed)
+        connect(self.screen, "active-workspace-changed",
+                self.__on_desktop_changed)
 
         self.__on_active_window_changed(self.screen, None)
         # Since the old container is destroyed we need to tell


### PR DESCRIPTION
Fixes #21.

`reload()` leaves state behind on every call, and it is easy to call — the `Reload`
D-Bus method, the **Reload** item in the dock's own menu. After about a hundred
reloads the dock here sat at 71% CPU, its icons stopped reacting to clicks, and it no
longer answered its own D-Bus interface, `Peer.Ping` included. `SIGINT` could not end
it either, since the handler runs on the main loop that was no longer being served —
only `SIGKILL`.

Two things accumulate.

**Screen handlers.** The five handlers are connected at the end of every reload and
never disconnected, while `Wnck.Screen.get_default()` is assigned once in `__init__`
and outlives them all. Every window event then runs every set, and the stale ones touch
state `reload()` has discarded — `AttributeError: 'Window' object has no attribute
'wnck'` out of `windowbutton.py set_preview_image()`, plus X `BadMatch`, hundreds of
each in `~/.xsession-errors`. This connects them through the `Connector` in `common.py`,
the same `connect()`/`disconnect()` the window signals already go through, and drops the
previous set when the reload starts.

**Group buttons.** The teardown loop removes from the list it is iterating, and
`GroupList` is a `list`, so only every other group is `destroy()`ed. `destroy()` is
where a group disconnects what it, its window buttons and its popup hold on the
`globals` singleton. Iterating over a copy fixes it.

Measured over 60 D-Bus reloads, CPU time per reload, in blocks of 20:

| | 1-20 | 21-40 | 41-60 | after |
|---|---|---|---|---|
| before | 1.86 s | 2.49 s | 3.01 s | wedged, `SIGKILL` needed |
| after | 1.70 s | 1.72 s | 2.00 s | responsive, no `AttributeError` at all |

Something still leaks beyond these two — over 120 reloads RSS went 89 MB → 182 MB and
per-reload CPU 1.7 s → 3.0 s — but the dock stays usable, which it did not before.
`Group.destroy()` looks complete on inspection, so finding the rest needs profiling
inside the process; happy to keep digging if it is worth a separate issue.

Independent of #19 / #20 — applies on its own.
